### PR TITLE
Upgrade nltk for py3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,6 @@ license_n_gram_lib.pickle
 /test.pickle
 /ENV
 .coverage
+.coverage.*
 coverage.xml
+.tox/

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
         "chardet",
         "comment-filter @ https://github.com/codeauroraforum/comment-filter/tarball/v1.0.0",
         "future",
-        "nltk==3.2.1",
+        "nltk<4",
         "pyyaml",
         "rdflib",
         "six",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy3,py36
++envlist = py{27,36,37,py}
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
The nltk package has added support for py36 and py37 in later versions,
and needs to be upgraded to support downstream lid dependencies.

Signed-off-by: Craig Northway <cnorthway@codeaurora.org>