### PR TITLE
Explicitly invoke tox for all pythons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,4 @@ jobs:
       - checkout
       - run:
          command: |-
-             apt-get update
-             apt-get install -y software-properties-common
-             add-apt-repository -y ppa:pypy/ppa
-             apt-get update
-             apt-get install -y pypy
-             tox
+             tox -e pypy3,py27,py36,py37


### PR DESCRIPTION
Otherwise it is not recognizing the different interpreters specified in tox.ini when running in CI

Signed-off-by: Craig Northway <cnorthway@codeaurora.org>